### PR TITLE
Remove use of attr_accessor_with_default

### DIFF
--- a/lib/lighthouse/tag.rb
+++ b/lib/lighthouse/tag.rb
@@ -1,8 +1,9 @@
-require 'active_support/core_ext/module/attr_accessor_with_default'
-
 module Lighthouse
   class Tag < String
-    attr_accessor_with_default :prefix_options, {}
+    attr_accessor :prefix_options
+    def prefix_options
+      @prefix_options ||= {}
+    end
     attr_accessor :project_id
 
     def initialize(s, project_id)


### PR DESCRIPTION
As per the [support ticket](http://help.lighthouseapp.com/discussions/api-developers/267-ruby-lighthouse-api-gem-uses-removed-activesupport-core-extension) I raised, ActiveSupport as of at least 3.2 (I haven't looked at 3.1) no longer has the core extension `Module#attr_accessor_with_default`. I've replaced it with a plain ruby equivalent and removed the dependency.

Cheers,
Simon
