### PR TITLE
Unable to load Ticket resources

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,12 +17,35 @@ GEM
     activesupport (3.2.13)
       i18n (= 0.6.1)
       multi_json (~> 1.0)
+    addressable (2.3.8)
     builder (3.0.4)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.2.5)
     i18n (0.6.1)
     multi_json (1.7.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-support (3.2.2)
+    safe_yaml (1.0.4)
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   lighthouse-api!
+  rspec (~> 3.2.0)
+  webmock (~> 1.21.0)

--- a/lib/lighthouse.rb
+++ b/lib/lighthouse.rb
@@ -8,7 +8,7 @@ require 'active_resource'
 # required for ruby < 1.9. constants(false) emaulation in active_support is buggy.
 require 'lighthouse/base'
 
-# Ruby lib for working with the Lighthouse API's XML interface.  
+# Ruby lib for working with the Lighthouse API's XML interface.
 # The first thing you need to set is the account name.  This is the same
 # as the web address for your account.
 #
@@ -30,11 +30,12 @@ require 'lighthouse/base'
 # http://lighthouseapp.com/api.
 #
 module Lighthouse
-  
+
   extend ActiveSupport::Autoload
-  
+
   autoload :Bin
   autoload :Changeset
+  autoload :Formats
   autoload :Membership
   autoload :Message
   autoload :Milestone
@@ -45,11 +46,11 @@ module Lighthouse
   autoload :Ticket
   autoload :Token
   autoload :User
-  
+
   class Error < StandardError; end
-  
+
   class Change < Array; end
-  
+
   class << self
     attr_accessor :account, :email, :password, :host_format, :domain_format, :protocol, :port
     attr_reader :token
@@ -58,7 +59,7 @@ module Lighthouse
     def authenticate(email, password)
       self.email    = email
       self.password = password
-      
+
       resources.each do |klass|
         update_auth(klass)
       end
@@ -75,22 +76,22 @@ module Lighthouse
     def resources
       @resources ||= []
     end
-    
+
     def update_site(resource)
       resource.site = resource.site_format % (host_format % [protocol, domain_format % account, ":#{port}"])
     end
-    
+
     def update_token_header(resource)
       resource.headers['X-LighthouseToken'] = token if token
     end
-    
+
     def update_auth(resource)
       return unless email && password
       resource.user     = email
       resource.password = password
     end
   end
-  
+
   self.host_format   = '%s://%s%s'
   self.domain_format = '%s.lighthouseapp.com'
   self.protocol      = 'http'

--- a/lib/lighthouse.rb
+++ b/lib/lighthouse.rb
@@ -8,7 +8,7 @@ require 'active_resource'
 # required for ruby < 1.9. constants(false) emaulation in active_support is buggy.
 require 'lighthouse/base'
 
-# Ruby lib for working with the Lighthouse API's XML interface.
+# Ruby lib for working with the Lighthouse API's XML interface.  
 # The first thing you need to set is the account name.  This is the same
 # as the web address for your account.
 #
@@ -30,9 +30,9 @@ require 'lighthouse/base'
 # http://lighthouseapp.com/api.
 #
 module Lighthouse
-
+  
   extend ActiveSupport::Autoload
-
+  
   autoload :Bin
   autoload :Changeset
   autoload :Formats
@@ -46,11 +46,11 @@ module Lighthouse
   autoload :Ticket
   autoload :Token
   autoload :User
-
+  
   class Error < StandardError; end
-
+  
   class Change < Array; end
-
+  
   class << self
     attr_accessor :account, :email, :password, :host_format, :domain_format, :protocol, :port
     attr_reader :token
@@ -59,7 +59,7 @@ module Lighthouse
     def authenticate(email, password)
       self.email    = email
       self.password = password
-
+      
       resources.each do |klass|
         update_auth(klass)
       end
@@ -76,22 +76,22 @@ module Lighthouse
     def resources
       @resources ||= []
     end
-
+    
     def update_site(resource)
       resource.site = resource.site_format % (host_format % [protocol, domain_format % account, ":#{port}"])
     end
-
+    
     def update_token_header(resource)
       resource.headers['X-LighthouseToken'] = token if token
     end
-
+    
     def update_auth(resource)
       return unless email && password
       resource.user     = email
       resource.password = password
     end
   end
-
+  
   self.host_format   = '%s://%s%s'
   self.domain_format = '%s.lighthouseapp.com'
   self.protocol      = 'http'

--- a/lib/lighthouse/formats.rb
+++ b/lib/lighthouse/formats.rb
@@ -1,0 +1,5 @@
+module Lighthouse
+  module Formats
+    autoload :TicketXml, 'lighthouse/formats/ticket_xml'
+  end
+end

--- a/lib/lighthouse/formats/ticket_xml.rb
+++ b/lib/lighthouse/formats/ticket_xml.rb
@@ -1,0 +1,22 @@
+require 'rexml/document'
+
+module Lighthouse
+  module Formats
+    module TicketXml
+      include ActiveResource::Formats::XmlFormat
+      extend self
+
+      def decode(xml)
+        doc = REXML::Document.new(xml)
+
+        total_pages  = doc.root.elements['//total_pages']
+        current_page = doc.root.elements['//current_page']
+
+        doc.root.elements.delete(total_pages)
+        doc.root.elements.delete(current_page)
+
+        super(doc.to_s)
+      end
+    end
+  end
+end

--- a/lib/lighthouse/ticket.rb
+++ b/lib/lighthouse/ticket.rb
@@ -27,6 +27,7 @@ module Lighthouse
     
     attr_writer :tags
     site_format << '/projects/:project_id'
+    self.format = Lighthouse::Formats::TicketXml
 
     def id
       attributes['number'] ||= nil

--- a/lighthouse-api.gemspec
+++ b/lighthouse-api.gemspec
@@ -15,8 +15,11 @@ Gem::Specification.new do |s|
   s.rubygems_version = '1.2.0'
   s.summary = %q{Ruby API wrapper for Lighthouse - http://lighthouseapp.com}
   s.description = %q{Ruby API wrapper for Lighthouse - http://lighthouseapp.com}
-  s.test_files = []
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   s.add_dependency(%q<activesupport>, [">= 3.0.0"])
   s.add_dependency(%q<activeresource>, [">= 3.0.0"])
+
+  s.add_development_dependency 'rspec', '~> 3.2.0'
+  s.add_development_dependency 'webmock', '~> 1.21.0'
 end

--- a/spec/lib/ticket_spec.rb
+++ b/spec/lib/ticket_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe Lighthouse::Ticket do
+  let(:xml) { <<-EOF
+    <tickets type="array">
+      <total_pages>141</total_pages>
+      <current_page>1</current_page>
+      <ticket>
+        <state>hold</state>
+        <tag>bug</tag>
+        <title>title</title>
+      </ticket>
+      <ticket>
+        <state>closed</state>
+        <tag>feature</tag>
+        <title>title</title>
+      </ticket>
+    </tickets>
+    EOF
+  }
+
+  before do
+    stub_request(:get, "http://test.lighthouseapp.com/projects/1/tickets.xml").
+      to_return(status: 200, body: xml, headers: {})
+  end
+
+  context 'all' do
+    it 'will return two tickets' do
+      tickets = Lighthouse::Ticket.all(params: {project_id: 1})
+
+      expect(tickets.count).to eq 2
+    end
+  end
+end

--- a/spec/lib/ticket_spec.rb
+++ b/spec/lib/ticket_spec.rb
@@ -18,15 +18,23 @@ RSpec.describe Lighthouse::Ticket do
   }
 
   before do
-    stub_request(:get, "http://test.lighthouseapp.com/projects/1/tickets.xml").
+    stub_request(:get, 'http://test.lighthouseapp.com/projects/1/tickets.xml').
       to_return(status: 200, body: xml, headers: {})
   end
 
   context 'all' do
-    it 'will return two tickets' do
-      tickets = Lighthouse::Ticket.all(params: {project_id: 1})
+    let(:tickets) { Lighthouse::Ticket.all(params: { project_id: 1 }) }
 
+    it 'will return two tickets' do
       expect(tickets.count).to eq 2
+    end
+
+    it 'will return ticket objects' do
+      ticket = tickets.first
+
+      expect(ticket.state).to eq 'hold'
+      expect(ticket.tag).to eq 'bug'
+      expect(ticket.title).to eq 'title'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+require_relative '../lib/lighthouse'
+require 'webmock/rspec'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end
+
+Lighthouse.account = 'test'
+Lighthouse.token = 'token'


### PR DESCRIPTION
Hey Folks,

I'm not sure if the Lighthouse API has changed but I'm seeing the response from `/tickets.xml` failing to load the ticket resources. I've included a spec to demonstrate the problem but it can be replicated by doing the following.

`Ticket.find(:all, params: {project_id: 1}) # => expected an attributes Hash, got "141"`. 

The response is returning the `total_pages` and `current_page` elements within the tickets array which means `Hash.from_xml` within `ActiveSupport` is unable to parse it.

```xml
<tickets type="array">
      <total_pages>141</total_pages>
      <current_page>1</current_page>
      <ticket>
       ...
      </ticket>
      <ticket>
       ...
      </ticket>
</tickets>
```

This removes the elements before passing it on to `ActiveResource::Formats::XmlFormat`, does this feel like something `lighthouse-api` should be responsible for handling?